### PR TITLE
If order expires after 1 month in the future, change it to 1 month

### DIFF
--- a/cmd/albiondata-sql/albiondata-sql.go
+++ b/cmd/albiondata-sql/albiondata-sql.go
@@ -128,6 +128,11 @@ func updateOrCreateOrder(db *gorm.DB, io *adclib.MarketOrder) error {
 		if err != nil {
 			return fmt.Errorf("while parsing the time of order id %d, error was: %s", io.ID, err)
 		}
+		maxTime := time.Now();
+		maxTime.AddDate(0, 1, 0);
+		if t.After(maxTime) {
+			t = maxTime;
+		}
 		mo.Expires = t
 
 		//fmt.Printf("Creating: %d - %s at %s\n", mo.AlbionID, mo.ItemID, mo.Location.String())


### PR DESCRIPTION
the expiration date for black market orders is set to year 3017 and if you use MySQL as a backend it will complain the date is invalid.

this change makes 1 month in the future the maximum possible expiration.. anything that expires after 1 month is changed to 1 month.