### PR TITLE
Fix Gold price timestamps

### DIFF
--- a/cmd/albiondata-sql/albiondata-sql.go
+++ b/cmd/albiondata-sql/albiondata-sql.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const secondsFrom0ToUnix = int64(62167132800)
+const secondsFrom0ToUnix = int64(62135596800)
 
 var (
 	version string


### PR DESCRIPTION
Updated the constant used to convert GameTimeStamps to UNIX timestamps. Old one was off by one year.